### PR TITLE
[Fix #72] Hero screen size for all viewports

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1192,39 +1192,39 @@ li.tg-rss a{background:#ff6600;}
   position:relative;
 }
 .tg-bannerimg figcaption{
-	width:100%;
-	float:left;
-	height: 100vh;
-	text-align:center;
-	-webkit-box-align: center;
-	-ms-flex-align: center;
-	align-items: center;
-	display: -webkit-box;
-	display: -ms-flexbox;
-	display: flex;
-	-webkit-box-orient: vertical;
-	justify-content: center;
-	-webkit-box-pack: center;
-	-ms-flex-pack: center;
-	-webkit-box-direction: normal;
-	-ms-flex-direction: column;
-	flex-direction: column;
-	background:
-		-moz-linear-gradient(top,
-		rgba(68,67,73,0.85) 0%,
-		rgba(70,66,73,0.85) 1%,
-		rgba(217,8,69,0.85) 60%);
-	background:
-		-webkit-linear-gradient(top,
-		rgba(68,67,73,0.85) 0%,
-		rgba(70,66,73,0.85) 1%,
-		rgba(217,8,69,0.85) 60%);
-	background:
-		linear-gradient(to bottom,
-		rgba(68,67,73,0.85) 0%,
-		rgba(70,66,73,0.85) 1%,
-		rgba(217,8,69,0.85) 60%);
-	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#d9444349', endColorstr='#d9d90845',GradientType=0 );
+  width:100%;
+  float:left;
+  height: 100vh;
+  text-align:center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: vertical;
+  justify-content: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  background:
+    -moz-linear-gradient(top,
+    rgba(68,67,73,0.85) 0%,
+    rgba(70,66,73,0.85) 1%,
+    rgba(217,8,69,0.85) 60%);
+  background:
+    -webkit-linear-gradient(top,
+    rgba(68,67,73,0.85) 0%,
+    rgba(70,66,73,0.85) 1%,
+    rgba(217,8,69,0.85) 60%);
+  background:
+    linear-gradient(to bottom,
+    rgba(68,67,73,0.85) 0%,
+    rgba(70,66,73,0.85) 1%,
+    rgba(217,8,69,0.85) 60%);
+ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#d9444349', endColorstr='#d9d90845',GradientType=0 );
 }
 .tg-slidercontent{
   width:100%;
@@ -4941,5 +4941,5 @@ body.tg-comingsoonpage .tg-foorterbar .tg-socialicons{padding:0;}
 }
 
 .height-100vh {
-	height: 100vh;
+  height: 100vh;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -4939,7 +4939,3 @@ body.tg-comingsoonpage .tg-foorterbar .tg-socialicons{padding:0;}
 .hr-statistics{
   color: white;
 }
-
-.height-100vh {
-  height: 100vh;
-}

--- a/css/main.css
+++ b/css/main.css
@@ -1194,7 +1194,7 @@ li.tg-rss a{background:#ff6600;}
 .tg-bannerimg figcaption{
 	width:100%;
 	float:left;
-	height: 945px;
+	height: 100vh;
 	text-align:center;
 	-webkit-box-align: center;
 	-ms-flex-align: center;
@@ -1226,7 +1226,6 @@ li.tg-rss a{background:#ff6600;}
 		rgba(217,8,69,0.85) 60%);
 	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#d9444349', endColorstr='#d9d90845',GradientType=0 );
 }
-.tg-homebannervtwo .tg-bannerimg figcaption{height: 100%;}
 .tg-slidercontent{
 	width:100%;
 	float:left;
@@ -4941,3 +4940,6 @@ body.tg-comingsoonpage .tg-foorterbar .tg-socialicons{padding:0;}
 	color: white;
 }
 
+.height-100vh {
+	height: 100vh;
+}

--- a/css/responsive.css
+++ b/css/responsive.css
@@ -1033,4 +1033,3 @@
 	}
 	.tg-headervfour .tg-navigationarea .tg-btnbookseat{float:left;}
 }
-@media (max-width:320px){}

--- a/css/responsive.css
+++ b/css/responsive.css
@@ -40,7 +40,7 @@
 		font-size: 40px;
 		line-height: 35px;
 	}
-	
+
 	.tg-tagsshare .tg-tags{
 		width:100%;
 		padding:0 0 20px;
@@ -135,7 +135,6 @@
 	.tg-bannerholdervthree .tg-bannerimg figcaption {height: 500px;}
 	.tg-bannerholdervthree .tg-slidercontent {padding: 35px 20px;}
 	.tg-upcomingeventcounter {padding: 0;}
-	.tg-bannerimg figcaption {height: 830px;}
 	.tg-date {padding: 20px 10px;}
 	.tg-date h3 {
 		font-size: 25px;
@@ -384,7 +383,6 @@
 	}
 }
 @media (max-width:900px){
-	.tg-bannerimg figcaption {height: 750px;}
 	.tg-slidercontent h1 {
 		font-size: 50px;
 		line-height: 50px;
@@ -480,7 +478,6 @@
 		font-size: 25px;
 		line-height: 25px;
 	}
-	.tg-bannerimg figcaption {height: 700px;}
 	.tg-eventcounter span:last-child {
 		right: -5px;
 		bottom: -10px;
@@ -503,7 +500,6 @@
 		font-size:12px;
 		line-height: 22px;
 	}
-	.tg-bannerimg figcaption {height: 570px;}
 	.tg-slidercontent > span {
 		font-size: 20px;
 		line-height: 20px;
@@ -837,7 +833,6 @@
 	.tg-bannersocialicons{left:20px;}
 	.tg-homeslider .owl-dots{right:20px;}
 	.tg-upcomingeventcounter {padding: 0 40px;}
-	.tg-bannerimg figcaption {height: 730px;}
 	.tg-eventcounterholder{
 		width:50%;
 		padding:10px;


### PR DESCRIPTION
![screenshot from 2017-08-03 12-11-24](https://user-images.githubusercontent.com/16102594/28909214-1cef8798-7845-11e7-9289-20af3565f52b.png)

The hero screen was overflowing on mobile screens so i made it's height to 100vh so that it looks same on all devices. Below is the updated screenshot:

![screenshot from 2017-08-03 12-15-13](https://user-images.githubusercontent.com/16102594/28909290-7840e6be-7845-11e7-91e3-0ffd13f7fea5.png)


