### PR TITLE
Timings on 4-5 Nov registrations

### DIFF
--- a/data/api/schedule.json
+++ b/data/api/schedule.json
@@ -179,7 +179,7 @@
           "talk_id": "00",
           "title": "Registration",
           "start_time": "08:00",
-          "end_time": "09:00",
+          "end_time": "09:30",
           "track": "all"
         },
         {
@@ -342,7 +342,7 @@
           "talk_id": "00",
           "title": "Registration",
           "start_time": "08:00",
-          "end_time": "09:00",
+          "end_time": "09:30",
           "track": "all"
         },
         {


### PR DESCRIPTION
There doesn't seem to be anything between 9:00 to 9:30 on 4th and 5th November , where as on 2nd and 4th November the events are just one after other.
Sorry , if the timings were intentionally so .